### PR TITLE
Parquet file reader

### DIFF
--- a/ibmetrics/metrics.py
+++ b/ibmetrics/metrics.py
@@ -39,14 +39,26 @@ def make_summary(builds: pandas.DataFrame) -> Dict[str, Any]:
     Return a dictionary that summarises the data in builds.
     The dictionary can be consumed by summarise() to create a human-readable text summary of the data.
     """
+
+    def has_value(val):
+        # Truthiness of value that can be None, list, dictionary, or numpy array.
+        # Needed because the truthiness of numpy.array (i.e., bool(np.array)) is ambiguous and causes errors.
+        if val is None:
+            return False
+
+        if len(val) == 0:
+            return False
+
+        return True
+
     summary = {
         "start": builds["created_at"].min(),
         "end": builds["created_at"].max(),
         "n builds": builds.shape[0],
         "n users": builds["org_id"].nunique(),
-        "n builds with packages": builds["packages"].apply(bool).sum(),
-        "n builds with fs customizations": builds["filesystem"].apply(bool).sum(),
-        "n builds with custom repos": builds["payload_repositories"].apply(bool).sum(),
+        "n builds with packages": builds["packages"].apply(has_value).sum(),
+        "n builds with fs customizations": builds["filesystem"].apply(has_value).sum(),
+        "n builds with custom repos": builds["payload_repositories"].apply(has_value).sum(),
     }
 
     return summary

--- a/ibmetrics/reader.py
+++ b/ibmetrics/reader.py
@@ -1,6 +1,7 @@
 """
 The reader module provides functions for loading data.
 """
+import glob
 import json
 import os
 import re
@@ -73,3 +74,30 @@ def read_dump(fname: Union[os.PathLike, str]) -> pandas.DataFrame:
               file=sys.stderr)
 
     return df
+
+
+def read_parquet(path: Union[os.PathLike, str]) -> pandas.DataFrame:
+    """
+    Read data from a directory of parquet files. Data in the files are concatenated into a single DataFrame.
+    Only files in the directory with the .parquet extension are loaded. Other files are ignored. Subdirectories are not
+    traversed.
+    """
+    filelist = glob.glob(os.path.join(path, "*.parquet"))
+    if not filelist:
+        print(f"WARNING: no .parquet files found in {path}")
+        return pandas.DataFrame()
+
+    dataframes = []
+    for fname in filelist:
+        dataframes.append(pandas.read_parquet(fname))
+
+    builds = pandas.concat(dataframes, ignore_index=True)
+
+    return builds
+
+
+def read(path: Union[os.PathLike, str]) -> pandas.DataFrame:
+    """
+    Alias for read_parquet()
+    """
+    return read_parquet(path)


### PR DESCRIPTION
Our new exporter (floorist) creates multiple parquet files, one for every 1000 database rows.  The new reader takes a directory as argument and reads all .parquet files found in that directory (non-recursively) and concatenates all the data into a single DataFrame.